### PR TITLE
Reformat code + allow for generic CAN_COMMON interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # SimpleISA
 Simple library for IVT shunts. 
 Based on the EVTV library of 2016, revised for use with CHAdeMO.
-Compatible with Arduino Due
 
 I managed to program ISA code to see +/- keys for innitializing different direction for current reporting.
-Replace your code with files inside SimpleISA.zip
-Replace your ino file with LeafVCUChademo.zip if you use it with that VCU otherwise see details within and adjust your code.
 
 When in serial monitor inside settings menu you can select +/- keys to innitialize positive or negative current orientation
 I am pretty sure i could make the same interface for voltage too.
+
+*Update Feb 05,2025 by @outlandnish*: Adapted to work with any CAN_COMMON provider (e.g. MCP2515, ESP32, etc.). 

--- a/SimpleISA.cpp
+++ b/SimpleISA.cpp
@@ -1,609 +1,592 @@
 /*  This library supports ISA Scale IVT Modular current/voltage sensor device.  These devices measure current, up to three voltages, and provide temperature compensation.
 
 
-    
-    This library was written by Jack Rickard of EVtv - http://www.evtv.me
-    copyright 2014
-    You are licensed to use this library for any purpose, commercial or private, 
-    without restriction.
-    
-*/
 
+  This library was written by Jack Rickard of EVtv - http://www.evtv.me
+  copyright 2014
+  You are licensed to use this library for any purpose, commercial or private,
+  without restriction.
+
+*/
 
 #include <SimpleISA.h>
 
-template<class T> inline Print &operator <<(Print &obj, T arg) { obj.print(arg); return obj; } 
-
-
-ISA::ISA()  // Define the constructor.
+template <class T>
+inline Print &operator<<(Print &obj, T arg)
 {
-  
-	 timestamp = millis(); 
-	 debug=false;
-	 debug2=false;
-	 framecount=0;
-	firstframe=true;
+  obj.print(arg);
+  return obj;
 }
 
+ISA::ISA(CAN_COMMON *port, int enablePin) // Define the constructor.
+{
+  this->port = port;
+  this->enablePin = enablePin;
 
-ISA::~ISA() //Define destructor
+  timestamp = millis();
+  debug = false;
+  debug2 = false;
+  framecount = 0;
+  firstframe = true;
+}
+
+ISA::~ISA() // Define destructor
 {
 }
 
-void ISA::begin(int Port, int speed)
+void ISA::begin(int speed)
 {
-  
- if (Port == 0)
-  {
-    canPort = &Can0;
-	  canEnPin = 255;
-	  canSpeed = speed * 1000;
-  }
-  else
-  {
-      canPort = &Can1;
-	  canEnPin = 255;
-	  canSpeed = speed * 1000;
-      
-  }
+  canSpeed = speed * 1000;
 
-  canPort->begin(canSpeed, canEnPin);
-  canPort->attachObj(this);
+  enablePin == -1 ? port->begin(speed) : port->begin(speed, enablePin);
+  port->begin();
+  port->attachObj(this);
   attachMBHandler(0);
-  //initCurrent();  
-  
+  // initCurrent();
 }
-
-
 
 void ISA::gotFrame(CAN_FRAME *frame, int mailbox)
- 
-//This is our CAN interrupt service routine to catch inbound frames
 {
+  // This is our CAN interrupt service routine to catch inbound frames
+  switch (frame->id)
+  {
+  case 0x511:
 
+    break;
 
-   switch (frame->id)
-     {
-     case 0x511:
-      
-      break;
-      
-     case 0x521:    
-      	handle521(frame);
-      break;
-      
-     case 0x522:    
-      	handle522(frame);
-      break;
-      
-      case 0x523:    
-      	handle523(frame);
-      break;
-      
-      case 0x524:    
-      	handle524(frame);
-      break;
-      
-      case 0x525:    
-      	handle525(frame);	
-      break;
-      
-      case 0x526:    
-      	handle526(frame);	
-      break;
-      
-      case 0x527:    
-      	handle527(frame);	
-      break;
-      
-      case 0x528:
-       	handle528(frame);   
-        break;
-     } 
-       
-     if(debug)printCAN(frame);
+  case 0x521:
+    handle521(frame);
+    break;
+
+  case 0x522:
+    handle522(frame);
+    break;
+
+  case 0x523:
+    handle523(frame);
+    break;
+
+  case 0x524:
+    handle524(frame);
+    break;
+
+  case 0x525:
+    handle525(frame);
+    break;
+
+  case 0x526:
+    handle526(frame);
+    break;
+
+  case 0x527:
+    handle527(frame);
+    break;
+
+  case 0x528:
+    handle528(frame);
+    break;
+  }
+
+  if (debug)
+    printCAN(frame);
 }
 
-void ISA::handle521(CAN_FRAME *frame)  //AMperes
+void ISA::handle521(CAN_FRAME *frame) // AMperes
 
-{	
-	framecount++;
-	long current=0;
-    current = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
-    
-    milliamps=current;
-    Amperes=current/1000.0f;
+{
+  framecount++;
+  long current = 0;
+  current = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
 
-     if(debug2)Serial<<"Current: "<<Amperes<<" amperes "<<milliamps<<" ma frames:"<<framecount<<"\n";
-    	
+  milliamps = current;
+  Amperes = current / 1000.0f;
+
+  if (debug2)
+    Serial << "Current: " << Amperes << " amperes " << milliamps << " ma frames:" << framecount << "\n";
 }
 
-void ISA::handle522(CAN_FRAME *frame)  //Voltage
+void ISA::handle522(CAN_FRAME *frame) // Voltage
 
-{	
-	framecount++;
-	long volt=0;
-    volt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
-    
-    Voltage=volt/1000.0f;
-	Voltage1=Voltage-(Voltage2+Voltage3);
-  if(framecount<150)
-    {
-      VoltageLO=Voltage;
-      Voltage1LO=Voltage1;
-    }
-  if(Voltage<VoltageLO &&  framecount>150)VoltageLO=Voltage;
-  if(Voltage>VoltageHI && framecount>150)VoltageHI=Voltage;
-  if(Voltage1<Voltage1LO && framecount>150)Voltage1LO=Voltage1;
-  if(Voltage1>Voltage1HI && framecount>150)Voltage1HI=Voltage1;
-  
-    if(debug2)Serial<<"Voltage: "<<Voltage<<" vdc Voltage 1: "<<Voltage1<<" vdc "<<volt<<" mVdc frames:"<<framecount<<"\n";
-     	
+{
+  framecount++;
+  long volt = 0;
+  volt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+
+  Voltage = volt / 1000.0f;
+  Voltage1 = Voltage - (Voltage2 + Voltage3);
+  if (framecount < 150)
+  {
+    VoltageLO = Voltage;
+    Voltage1LO = Voltage1;
+  }
+  if (Voltage < VoltageLO && framecount > 150)
+    VoltageLO = Voltage;
+  if (Voltage > VoltageHI && framecount > 150)
+    VoltageHI = Voltage;
+  if (Voltage1 < Voltage1LO && framecount > 150)
+    Voltage1LO = Voltage1;
+  if (Voltage1 > Voltage1HI && framecount > 150)
+    Voltage1HI = Voltage1;
+
+  if (debug2)
+    Serial << "Voltage: " << Voltage << " vdc Voltage 1: " << Voltage1 << " vdc " << volt << " mVdc frames:" << framecount << "\n";
 }
 
-void ISA::handle523(CAN_FRAME *frame) //Voltage2
+void ISA::handle523(CAN_FRAME *frame) // Voltage2
 
-{	
-	framecount++;
-	long volt=0;
-    volt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
-    
-    Voltage2=volt/1000.0f;
-    if(Voltage2>3)Voltage2-=Voltage3;
-    if(framecount<150)Voltage2LO=Voltage2;
-    if(Voltage2<Voltage2LO  && framecount>150)Voltage2LO=Voltage2;
-    if(Voltage2>Voltage2HI&& framecount>150)Voltage2HI=Voltage2;
-    
-		
-     if(debug2)Serial<<"Voltage: "<<Voltage<<" vdc Voltage 2: "<<Voltage2<<" vdc "<<volt<<" mVdc frames:"<<framecount<<"\n";
- 
-   	
+{
+  framecount++;
+  long volt = 0;
+  volt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+
+  Voltage2 = volt / 1000.0f;
+  if (Voltage2 > 3)
+    Voltage2 -= Voltage3;
+  if (framecount < 150)
+    Voltage2LO = Voltage2;
+  if (Voltage2 < Voltage2LO && framecount > 150)
+    Voltage2LO = Voltage2;
+  if (Voltage2 > Voltage2HI && framecount > 150)
+    Voltage2HI = Voltage2;
+
+  if (debug2)
+    Serial << "Voltage: " << Voltage << " vdc Voltage 2: " << Voltage2 << " vdc " << volt << " mVdc frames:" << framecount << "\n";
 }
 
-void ISA::handle524(CAN_FRAME *frame)  //Voltage3
+void ISA::handle524(CAN_FRAME *frame) // Voltage3
 
-{	
-	framecount++;
-	long volt=0;
-    volt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
-    
-    Voltage3=volt/1000.0f;
-    if(framecount<150)Voltage3LO=Voltage3;
-    if(Voltage3<Voltage3LO && framecount>150 && Voltage3>10)Voltage3LO=Voltage3;
-    if(Voltage3>Voltage3HI && framecount>150)Voltage3HI=Voltage3;
-    
-     if(debug2)Serial<<"Voltage: "<<Voltage<<" vdc Voltage 3: "<<Voltage3<<" vdc "<<volt<<" mVdc frames:"<<framecount<<"\n";
+{
+  framecount++;
+  long volt = 0;
+  volt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+
+  Voltage3 = volt / 1000.0f;
+  if (framecount < 150)
+    Voltage3LO = Voltage3;
+  if (Voltage3 < Voltage3LO && framecount > 150 && Voltage3 > 10)
+    Voltage3LO = Voltage3;
+  if (Voltage3 > Voltage3HI && framecount > 150)
+    Voltage3HI = Voltage3;
+
+  if (debug2)
+    Serial << "Voltage: " << Voltage << " vdc Voltage 3: " << Voltage3 << " vdc " << volt << " mVdc frames:" << framecount << "\n";
 }
 
-void ISA::handle525(CAN_FRAME *frame)  //Temperature
+void ISA::handle525(CAN_FRAME *frame) // Temperature
 
-{	
-	framecount++;
-	long temp=0;
-    temp = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
-    
-    Temperature=temp/10;
-		
-     if(debug2)Serial<<"Temperature: "<<Temperature<<" C  frames:"<<framecount<<"\n";
-   
+{
+  framecount++;
+  long temp = 0;
+  temp = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+
+  Temperature = temp / 10;
+
+  if (debug2)
+    Serial << "Temperature: " << Temperature << " C  frames:" << framecount << "\n";
 }
 
+void ISA::handle526(CAN_FRAME *frame) // Kilowatts
 
+{
+  framecount++;
+  watt = 0;
+  watt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
 
-void ISA::handle526(CAN_FRAME *frame) //Kilowatts
+  KW = watt / 1000.0f;
 
-{	
-	framecount++;
-	watt=0;
-    watt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
-    
-    KW=watt/1000.0f;
-		
-     if(debug2)Serial<<"Power: "<<watt<<" Watts  "<<KW<<" kW  frames:"<<framecount<<"\n";
-    
+  if (debug2)
+    Serial << "Power: " << watt << " Watts  " << KW << " kW  frames:" << framecount << "\n";
 }
 
+void ISA::handle527(CAN_FRAME *frame) // Ampere-Hours
 
-void ISA::handle527(CAN_FRAME *frame) //Ampere-Hours
+{
+  framecount++;
+  As = 0;
+  As = (frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]);
 
-{	
-	framecount++;
-	As=0;
-    As = (frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]);
-    
-    AH+=(As-lastAs)/3600.0f;
-    lastAs=As;
+  AH += (As - lastAs) / 3600.0f;
+  lastAs = As;
 
-		
-     if(debug2)Serial<<"Amphours: "<<AH<<"  Ampseconds: "<<As<<" frames:"<<framecount<<"\n";
-    
+  if (debug2)
+    Serial << "Amphours: " << AH << "  Ampseconds: " << As << " frames:" << framecount << "\n";
 }
 
-void ISA::handle528(CAN_FRAME *frame)  //kiloWatt-hours
+void ISA::handle528(CAN_FRAME *frame) // kiloWatt-hours
 
-{	
-	framecount++;
-	
-    wh = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
-    KWH+=(wh-lastWh)/1000.0f;
-	lastWh=wh;
-     if(debug2)Serial<<"KiloWattHours: "<<KWH<<"  Watt Hours: "<<wh<<" frames:"<<framecount<<"\n";
-   
+{
+  framecount++;
+
+  wh = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+  KWH += (wh - lastWh) / 1000.0f;
+  lastWh = wh;
+  if (debug2)
+    Serial << "KiloWattHours: " << KWH << "  Watt Hours: " << wh << " frames:" << framecount << "\n";
 }
-
 
 void ISA::printCAN(CAN_FRAME *frame)
 {
-	
-   //This routine simply prints a timestamp and the contents of the 
-   //incoming CAN message
-   
-	milliseconds = (int) (millis()/1) %1000 ;
-	seconds = (int) (millis() / 1000) % 60 ;
-    minutes = (int) ((millis() / (1000*60)) % 60);
-	hours   = (int) ((millis() / (1000*60*60)) % 24);
-	sprintf(buffer,"%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
-	Serial<<buffer<<" ";
-    sprintf(bigbuffer,"%02X %02X %02X %02X %02X %02X %02X %02X %02X", 
-    frame->id, frame->data.bytes[0],frame->data.bytes[1],frame->data.bytes[2],
-    frame->data.bytes[3],frame->data.bytes[4],frame->data.bytes[5],frame->data.bytes[6],frame->data.bytes[7],0);
-    Serial<<"Rcvd ISA frame: 0x"<<bigbuffer<<"\n";
-    
+
+  // This routine simply prints a timestamp and the contents of the
+  // incoming CAN message
+
+  milliseconds = (int)(millis() / 1) % 1000;
+  seconds = (int)(millis() / 1000) % 60;
+  minutes = (int)((millis() / (1000 * 60)) % 60);
+  hours = (int)((millis() / (1000 * 60 * 60)) % 24);
+  sprintf(buffer, "%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
+  Serial << buffer << " ";
+  sprintf(bigbuffer, "%02X %02X %02X %02X %02X %02X %02X %02X %02X",
+          frame->id, frame->data.bytes[0], frame->data.bytes[1], frame->data.bytes[2],
+          frame->data.bytes[3], frame->data.bytes[4], frame->data.bytes[5], frame->data.bytes[6], frame->data.bytes[7]);
+  Serial << "Rcvd ISA frame: 0x" << bigbuffer << "\n";
 }
 void ISA::initialize()
 {
-  
 
-	firstframe=false;
-	STOP();
-	delay(700);
-	for(int i=0;i<9;i++)
-	{
-	
-Serial.println("initialization \n");
-	
-	outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=(0x20+i);
-        outframe.data.bytes[1]=0x42;  
-        outframe.data.bytes[2]=0x02;
-        outframe.data.bytes[3]=(0x60+(i*18));
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
+  firstframe = false;
+  STOP();
+  delay(700);
+  for (int i = 0; i < 9; i++)
+  {
 
-	   canPort->sendFrame(outframe);
-     
-       if(debug)printCAN(&outframe);
-	   delay(500);
-      
-       sendSTORE();
-       delay(500);
-     }
-    //  delay(500);
-      START();
-      delay(500);
-      lastAs=As;
-      lastWh=wh;
+    Serial.println("initialization \n");
 
-                      
+    outframe.id = 0x411;   // Set our transmission address ID
+    outframe.length = 8;   // Data payload 8 bytes
+    outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+    outframe.rtr = 1;      // No request
+    outframe.data.bytes[0] = (0x20 + i);
+    outframe.data.bytes[1] = 0x42;
+    outframe.data.bytes[2] = 0x02;
+    outframe.data.bytes[3] = (0x60 + (i * 18));
+    outframe.data.bytes[4] = 0x00;
+    outframe.data.bytes[5] = 0x00;
+    outframe.data.bytes[6] = 0x00;
+    outframe.data.bytes[7] = 0x00;
+
+    port->sendFrame(outframe);
+
+    if (debug)
+      printCAN(&outframe);
+    delay(500);
+
+    sendSTORE();
+    delay(500);
+  }
+  //  delay(500);
+  START();
+  delay(500);
+  lastAs = As;
+  lastWh = wh;
 }
 
 void ISA::CPLUS()
 {
-  
 
-	firstframe=false;
-	STOP();
-	delay(700);
-	for(int i=0;i<9;i++)
-	{
-	
-Serial.println("set current plus \n");
-	
-	outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x20;
-        outframe.data.bytes[1]=0x42;  
-        outframe.data.bytes[2]=0x02;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
+  firstframe = false;
+  STOP();
+  delay(700);
+  for (int i = 0; i < 9; i++)
+  {
 
-	   canPort->sendFrame(outframe);
-     
-       if(debug)printCAN(&outframe);
-	   delay(500);
-      
-       sendSTORE();
-       delay(500);
-     }
-    //  delay(500);
-      START();
-      delay(500);
-      lastAs=As;
-      lastWh=wh;
+    Serial.println("set current plus \n");
 
-                      
+    outframe.id = 0x411;   // Set our transmission address ID
+    outframe.length = 8;   // Data payload 8 bytes
+    outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+    outframe.rtr = 1;      // No request
+    outframe.data.bytes[0] = 0x20;
+    outframe.data.bytes[1] = 0x42;
+    outframe.data.bytes[2] = 0x02;
+    outframe.data.bytes[3] = 0x00;
+    outframe.data.bytes[4] = 0x00;
+    outframe.data.bytes[5] = 0x00;
+    outframe.data.bytes[6] = 0x00;
+    outframe.data.bytes[7] = 0x00;
+
+    port->sendFrame(outframe);
+
+    if (debug)
+      printCAN(&outframe);
+    delay(500);
+
+    sendSTORE();
+    delay(500);
+  }
+  //  delay(500);
+  START();
+  delay(500);
+  lastAs = As;
+  lastWh = wh;
 }
-
 
 void ISA::CMINUS()
 {
-  
 
-	firstframe=false;
-	STOP();
-	delay(700);
-	for(int i=0;i<9;i++)
-	{
-	
-Serial.println("set current minus\n");
-	
-	outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x20;
-        outframe.data.bytes[1]=0xC2;  
-        outframe.data.bytes[2]=0x02;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
+  firstframe = false;
+  STOP();
+  delay(700);
+  for (int i = 0; i < 9; i++)
+  {
 
-	   canPort->sendFrame(outframe);
-     
-       if(debug)printCAN(&outframe);
-	   delay(500);
-      
-       sendSTORE();
-       delay(500);
-     }
-    //  delay(500);
-      START();
-      delay(500);
-      lastAs=As;
-      lastWh=wh;
-                      
+    Serial.println("set current minus\n");
+
+    outframe.id = 0x411;   // Set our transmission address ID
+    outframe.length = 8;   // Data payload 8 bytes
+    outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+    outframe.rtr = 1;      // No request
+    outframe.data.bytes[0] = 0x20;
+    outframe.data.bytes[1] = 0xC2;
+    outframe.data.bytes[2] = 0x02;
+    outframe.data.bytes[3] = 0x00;
+    outframe.data.bytes[4] = 0x00;
+    outframe.data.bytes[5] = 0x00;
+    outframe.data.bytes[6] = 0x00;
+    outframe.data.bytes[7] = 0x00;
+
+    port->sendFrame(outframe);
+
+    if (debug)
+      printCAN(&outframe);
+    delay(500);
+
+    sendSTORE();
+    delay(500);
+  }
+  //  delay(500);
+  START();
+  delay(500);
+  lastAs = As;
+  lastWh = wh;
 }
 
 void ISA::VPLUS()
 {
-  
 
-	firstframe=false;
-	STOP();
-	delay(700);
-	for(int i=0;i<9;i++)
-	{
-	
-Serial.println("set current plus \n");
-	
-	outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x21;
-        outframe.data.bytes[1]=0x42;  
-        outframe.data.bytes[2]=0x02;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
+  firstframe = false;
+  STOP();
+  delay(700);
+  for (int i = 0; i < 9; i++)
+  {
 
-	   canPort->sendFrame(outframe);
-     
-       if(debug)printCAN(&outframe);
-	   delay(500);
-      
-       sendSTORE();
-       delay(500);
-     }
-    //  delay(500);
-      START();
-      delay(500);
-      lastAs=As;
-      lastWh=wh;
+    Serial.println("set current plus \n");
 
-                      
+    outframe.id = 0x411;   // Set our transmission address ID
+    outframe.length = 8;   // Data payload 8 bytes
+    outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+    outframe.rtr = 1;      // No request
+    outframe.data.bytes[0] = 0x21;
+    outframe.data.bytes[1] = 0x42;
+    outframe.data.bytes[2] = 0x02;
+    outframe.data.bytes[3] = 0x00;
+    outframe.data.bytes[4] = 0x00;
+    outframe.data.bytes[5] = 0x00;
+    outframe.data.bytes[6] = 0x00;
+    outframe.data.bytes[7] = 0x00;
+
+    port->sendFrame(outframe);
+
+    if (debug)
+      printCAN(&outframe);
+    delay(500);
+
+    sendSTORE();
+    delay(500);
+  }
+  //  delay(500);
+  START();
+  delay(500);
+  lastAs = As;
+  lastWh = wh;
 }
-
 
 void ISA::VMINUS()
 {
-  
 
-	firstframe=false;
-	STOP();
-	delay(700);
-	for(int i=0;i<9;i++)
-	{
-	
-Serial.println("set current minus\n");
-	
-	outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x21;
-        outframe.data.bytes[1]=0xC2;  
-        outframe.data.bytes[2]=0x02;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
+  firstframe = false;
+  STOP();
+  delay(700);
+  for (int i = 0; i < 9; i++)
+  {
 
-	   canPort->sendFrame(outframe);
-     
-       if(debug)printCAN(&outframe);
-	   delay(500);
-      
-       sendSTORE();
-       delay(500);
-     }
-    //  delay(500);
-      START();
-      delay(500);
-      lastAs=As;
-      lastWh=wh;
-                      
+    Serial.println("set current minus\n");
+
+    outframe.id = 0x411;   // Set our transmission address ID
+    outframe.length = 8;   // Data payload 8 bytes
+    outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+    outframe.rtr = 1;      // No request
+    outframe.data.bytes[0] = 0x21;
+    outframe.data.bytes[1] = 0xC2;
+    outframe.data.bytes[2] = 0x02;
+    outframe.data.bytes[3] = 0x00;
+    outframe.data.bytes[4] = 0x00;
+    outframe.data.bytes[5] = 0x00;
+    outframe.data.bytes[6] = 0x00;
+    outframe.data.bytes[7] = 0x00;
+
+    port->sendFrame(outframe);
+
+    if (debug)
+      printCAN(&outframe);
+    delay(500);
+
+    sendSTORE();
+    delay(500);
+  }
+  //  delay(500);
+  START();
+  delay(500);
+  lastAs = As;
+  lastWh = wh;
 }
-
 
 void ISA::STOP()
 {
 
-//SEND STOP///////
+  // SEND STOP///////
 
-	    outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x34;
-        outframe.data.bytes[1]=0x00;  
-        outframe.data.bytes[2]=0x01;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
-		canPort->sendFrame(outframe);
-     
-        if(debug) {printCAN(&outframe);} //If the debug variable is set, show our transmitted frame
-} 
+  outframe.id = 0x411;   // Set our transmission address ID
+  outframe.length = 8;   // Data payload 8 bytes
+  outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+  outframe.rtr = 1;      // No request
+  outframe.data.bytes[0] = 0x34;
+  outframe.data.bytes[1] = 0x00;
+  outframe.data.bytes[2] = 0x01;
+  outframe.data.bytes[3] = 0x00;
+  outframe.data.bytes[4] = 0x00;
+  outframe.data.bytes[5] = 0x00;
+  outframe.data.bytes[6] = 0x00;
+  outframe.data.bytes[7] = 0x00;
+  port->sendFrame(outframe);
+
+  if (debug)
+  {
+    printCAN(&outframe);
+  } // If the debug variable is set, show our transmitted frame
+}
 void ISA::sendSTORE()
 {
 
-//SEND STORE///////
+  // SEND STORE///////
 
-	outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x32;
-        outframe.data.bytes[1]=0x00;  
-        outframe.data.bytes[2]=0x00;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
-		canPort->sendFrame(outframe);
-     
-        if(debug)printCAN(&outframe); //If the debug variable is set, show our transmitted frame
-        
-}   
+  outframe.id = 0x411;   // Set our transmission address ID
+  outframe.length = 8;   // Data payload 8 bytes
+  outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+  outframe.rtr = 1;      // No request
+  outframe.data.bytes[0] = 0x32;
+  outframe.data.bytes[1] = 0x00;
+  outframe.data.bytes[2] = 0x00;
+  outframe.data.bytes[3] = 0x00;
+  outframe.data.bytes[4] = 0x00;
+  outframe.data.bytes[5] = 0x00;
+  outframe.data.bytes[6] = 0x00;
+  outframe.data.bytes[7] = 0x00;
+  port->sendFrame(outframe);
+
+  if (debug)
+    printCAN(&outframe); // If the debug variable is set, show our transmitted frame
+}
 
 void ISA::START()
 {
-           
- //SEND START///////
 
-	    outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x34;
-        outframe.data.bytes[1]=0x01;  
-        outframe.data.bytes[2]=0x01;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
-		canPort->sendFrame(outframe);
-     
-        if(debug)printCAN(&outframe); //If the debug variable is set, show our transmitted frame
+  // SEND START///////
+
+  outframe.id = 0x411;   // Set our transmission address ID
+  outframe.length = 8;   // Data payload 8 bytes
+  outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+  outframe.rtr = 1;      // No request
+  outframe.data.bytes[0] = 0x34;
+  outframe.data.bytes[1] = 0x01;
+  outframe.data.bytes[2] = 0x01;
+  outframe.data.bytes[3] = 0x00;
+  outframe.data.bytes[4] = 0x00;
+  outframe.data.bytes[5] = 0x00;
+  outframe.data.bytes[6] = 0x00;
+  outframe.data.bytes[7] = 0x00;
+  port->sendFrame(outframe);
+
+  if (debug)
+    printCAN(&outframe); // If the debug variable is set, show our transmitted frame
 }
 
 void ISA::RESTART()
 {
-         //Has the effect of zeroing AH and KWH  
+  // Has the effect of zeroing AH and KWH
 
-	    outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x3F;
-        outframe.data.bytes[1]=0x00;  
-        outframe.data.bytes[2]=0x00;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
-		canPort->sendFrame(outframe);
-     
-        if(debug)printCAN(&outframe); //If the debug variable is set, show our transmitted frame
+  outframe.id = 0x411;   // Set our transmission address ID
+  outframe.length = 8;   // Data payload 8 bytes
+  outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+  outframe.rtr = 1;      // No request
+  outframe.data.bytes[0] = 0x3F;
+  outframe.data.bytes[1] = 0x00;
+  outframe.data.bytes[2] = 0x00;
+  outframe.data.bytes[3] = 0x00;
+  outframe.data.bytes[4] = 0x00;
+  outframe.data.bytes[5] = 0x00;
+  outframe.data.bytes[6] = 0x00;
+  outframe.data.bytes[7] = 0x00;
+  port->sendFrame(outframe);
+
+  if (debug)
+    printCAN(&outframe); // If the debug variable is set, show our transmitted frame
 }
-
 
 void ISA::deFAULT()
 {
-         //Returns module to original defaults  
+  // Returns module to original defaults
 
-	    outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x3D;
-        outframe.data.bytes[1]=0x00;  
-        outframe.data.bytes[2]=0x00;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
-		canPort->sendFrame(outframe);
-     
-        if(debug)printCAN(&outframe); //If the debug variable is set, show our transmitted frame
+  outframe.id = 0x411;   // Set our transmission address ID
+  outframe.length = 8;   // Data payload 8 bytes
+  outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+  outframe.rtr = 1;      // No request
+  outframe.data.bytes[0] = 0x3D;
+  outframe.data.bytes[1] = 0x00;
+  outframe.data.bytes[2] = 0x00;
+  outframe.data.bytes[3] = 0x00;
+  outframe.data.bytes[4] = 0x00;
+  outframe.data.bytes[5] = 0x00;
+  outframe.data.bytes[6] = 0x00;
+  outframe.data.bytes[7] = 0x00;
+  port->sendFrame(outframe);
+
+  if (debug)
+    printCAN(&outframe); // If the debug variable is set, show our transmitted frame
 }
-
 
 void ISA::initCurrent()
 {
-	STOP();
-	delay(500);
-	
-	
-Serial.println("initialization \n");
-	
-	outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=(0x21);
-        outframe.data.bytes[1]=0x42;  
-        outframe.data.bytes[2]=0x01;
-        outframe.data.bytes[3]=(0x61);
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
+  STOP();
+  delay(500);
 
-		canPort->sendFrame(outframe);
-     
-       if(debug)printCAN(&outframe);
-	delay(500);
-      
-       sendSTORE();
-       delay(500);
-    
-    //  delay(500);
-      START();
-      delay(500);
-      lastAs=As;
-      lastWh=wh;                      
+  Serial.println("initialization \n");
+
+  outframe.id = 0x411;   // Set our transmission address ID
+  outframe.length = 8;   // Data payload 8 bytes
+  outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
+  outframe.rtr = 1;      // No request
+  outframe.data.bytes[0] = (0x21);
+  outframe.data.bytes[1] = 0x42;
+  outframe.data.bytes[2] = 0x01;
+  outframe.data.bytes[3] = (0x61);
+  outframe.data.bytes[4] = 0x00;
+  outframe.data.bytes[5] = 0x00;
+  outframe.data.bytes[6] = 0x00;
+  outframe.data.bytes[7] = 0x00;
+
+  port->sendFrame(outframe);
+
+  if (debug)
+    printCAN(&outframe);
+  delay(500);
+
+  sendSTORE();
+  delay(500);
+
+  //  delay(500);
+  START();
+  delay(500);
+  lastAs = As;
+  lastWh = wh;
 }
-

--- a/SimpleISA.cpp
+++ b/SimpleISA.cpp
@@ -24,8 +24,6 @@ ISA::ISA(CAN_COMMON *port, int enablePin) // Define the constructor.
   this->enablePin = enablePin;
 
   timestamp = millis();
-  debug = false;
-  debug2 = false;
   framecount = 0;
   firstframe = true;
 }
@@ -87,8 +85,9 @@ void ISA::gotFrame(CAN_FRAME *frame, int mailbox)
     break;
   }
 
-  if (debug)
-    printCAN(frame);
+#if defined(DEBUG_ISA_OUTPUT)
+  printCAN(frame);
+#endif
 }
 
 void ISA::handle521(CAN_FRAME *frame) // AMperes
@@ -101,8 +100,10 @@ void ISA::handle521(CAN_FRAME *frame) // AMperes
   milliamps = current;
   Amperes = current / 1000.0f;
 
-  if (debug2)
-    Serial << "Current: " << Amperes << " amperes " << milliamps << " ma frames:" << framecount << "\n";
+#if defined(DEBUG_ISA_DATA)
+  Serial << "Current: " << 
+  Amperes << " amperes " << milliamps << " ma frames:" << framecount << "\n";
+#endif
 }
 
 void ISA::handle522(CAN_FRAME *frame) // Voltage
@@ -128,12 +129,12 @@ void ISA::handle522(CAN_FRAME *frame) // Voltage
   if (Voltage1 > Voltage1HI && framecount > 150)
     Voltage1HI = Voltage1;
 
-  if (debug2)
-    Serial << "Voltage: " << Voltage << " vdc Voltage 1: " << Voltage1 << " vdc " << volt << " mVdc frames:" << framecount << "\n";
+  #if defined(DEBUG_ISA_DATA)
+  Serial << "Voltage: " << Voltage << " vdc Voltage 1: " << Voltage1 << " vdc " << volt << " mVdc frames:" << framecount << "\n";
+  #endif
 }
 
 void ISA::handle523(CAN_FRAME *frame) // Voltage2
-
 {
   framecount++;
   long volt = 0;
@@ -149,12 +150,12 @@ void ISA::handle523(CAN_FRAME *frame) // Voltage2
   if (Voltage2 > Voltage2HI && framecount > 150)
     Voltage2HI = Voltage2;
 
-  if (debug2)
-    Serial << "Voltage: " << Voltage << " vdc Voltage 2: " << Voltage2 << " vdc " << volt << " mVdc frames:" << framecount << "\n";
+#if defined(DEBUG_ISA_DATA)
+  Serial << "Voltage: " << Voltage << " vdc Voltage 2: " << Voltage2 << " vdc " << volt << " mVdc frames:" << framecount << "\n";
+#endif
 }
 
 void ISA::handle524(CAN_FRAME *frame) // Voltage3
-
 {
   framecount++;
   long volt = 0;
@@ -168,12 +169,12 @@ void ISA::handle524(CAN_FRAME *frame) // Voltage3
   if (Voltage3 > Voltage3HI && framecount > 150)
     Voltage3HI = Voltage3;
 
-  if (debug2)
-    Serial << "Voltage: " << Voltage << " vdc Voltage 3: " << Voltage3 << " vdc " << volt << " mVdc frames:" << framecount << "\n";
+#if defined(DEBUG_ISA_DATA)
+  Serial << "Voltage: " << Voltage << " vdc Voltage 3: " << Voltage3 << " vdc " << volt << " mVdc frames:" << framecount << "\n";
+#endif
 }
 
 void ISA::handle525(CAN_FRAME *frame) // Temperature
-
 {
   framecount++;
   long temp = 0;
@@ -181,12 +182,12 @@ void ISA::handle525(CAN_FRAME *frame) // Temperature
 
   Temperature = temp / 10;
 
-  if (debug2)
-    Serial << "Temperature: " << Temperature << " C  frames:" << framecount << "\n";
+#if defined(DEBUG_ISA_DATA)
+  Serial << "Temperature: " << Temperature << " C  frames:" << framecount << "\n";
+#endif
 }
 
 void ISA::handle526(CAN_FRAME *frame) // Kilowatts
-
 {
   framecount++;
   watt = 0;
@@ -194,8 +195,9 @@ void ISA::handle526(CAN_FRAME *frame) // Kilowatts
 
   KW = watt / 1000.0f;
 
-  if (debug2)
-    Serial << "Power: " << watt << " Watts  " << KW << " kW  frames:" << framecount << "\n";
+#if defined(DEBUG_ISA_DATA)
+  Serial << "Power: " << watt << " Watts  " << KW << " kW  frames:" << framecount << "\n";
+#endif
 }
 
 void ISA::handle527(CAN_FRAME *frame) // Ampere-Hours
@@ -208,8 +210,9 @@ void ISA::handle527(CAN_FRAME *frame) // Ampere-Hours
   AH += (As - lastAs) / 3600.0f;
   lastAs = As;
 
-  if (debug2)
-    Serial << "Amphours: " << AH << "  Ampseconds: " << As << " frames:" << framecount << "\n";
+#if defined(DEBUG_ISA_DATA)
+  Serial << "Amphours: " << AH << "  Ampseconds: " << As << " frames:" << framecount << "\n";
+#endif
 }
 
 void ISA::handle528(CAN_FRAME *frame) // kiloWatt-hours
@@ -220,8 +223,10 @@ void ISA::handle528(CAN_FRAME *frame) // kiloWatt-hours
   wh = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
   KWH += (wh - lastWh) / 1000.0f;
   lastWh = wh;
-  if (debug2)
-    Serial << "KiloWattHours: " << KWH << "  Watt Hours: " << wh << " frames:" << framecount << "\n";
+
+#if defined(DEBUG_ISA_DATA)
+  Serial << "KiloWattHours: " << KWH << "  Watt Hours: " << wh << " frames:" << framecount << "\n";
+#endif
 }
 
 void ISA::printCAN(CAN_FRAME *frame)
@@ -241,15 +246,14 @@ void ISA::printCAN(CAN_FRAME *frame)
           frame->data.bytes[3], frame->data.bytes[4], frame->data.bytes[5], frame->data.bytes[6], frame->data.bytes[7]);
   Serial << "Rcvd ISA frame: 0x" << bigbuffer << "\n";
 }
+
 void ISA::initialize()
 {
-
   firstframe = false;
   STOP();
   delay(700);
   for (int i = 0; i < 9; i++)
   {
-
     Serial.println("initialization \n");
 
     outframe.id = 0x411;   // Set our transmission address ID
@@ -267,8 +271,10 @@ void ISA::initialize()
 
     port->sendFrame(outframe);
 
-    if (debug)
-      printCAN(&outframe);
+#if defined(DEBUG_CAN_FRAMES)
+    printCAN(&outframe);
+#endif
+
     delay(500);
 
     sendSTORE();
@@ -283,13 +289,11 @@ void ISA::initialize()
 
 void ISA::CPLUS()
 {
-
   firstframe = false;
   STOP();
   delay(700);
   for (int i = 0; i < 9; i++)
   {
-
     Serial.println("set current plus \n");
 
     outframe.id = 0x411;   // Set our transmission address ID
@@ -307,8 +311,9 @@ void ISA::CPLUS()
 
     port->sendFrame(outframe);
 
-    if (debug)
-      printCAN(&outframe);
+#if defined(DEBUG_ISA_OUTPUT)
+    printCAN(&outframe);
+#endif
     delay(500);
 
     sendSTORE();
@@ -323,13 +328,11 @@ void ISA::CPLUS()
 
 void ISA::CMINUS()
 {
-
   firstframe = false;
   STOP();
   delay(700);
   for (int i = 0; i < 9; i++)
   {
-
     Serial.println("set current minus\n");
 
     outframe.id = 0x411;   // Set our transmission address ID
@@ -347,8 +350,9 @@ void ISA::CMINUS()
 
     port->sendFrame(outframe);
 
-    if (debug)
-      printCAN(&outframe);
+#if defined(DEBUG_ISA_OUTPUT)
+    printCAN(&outframe);
+#endif
     delay(500);
 
     sendSTORE();
@@ -363,13 +367,11 @@ void ISA::CMINUS()
 
 void ISA::VPLUS()
 {
-
   firstframe = false;
   STOP();
   delay(700);
   for (int i = 0; i < 9; i++)
   {
-
     Serial.println("set current plus \n");
 
     outframe.id = 0x411;   // Set our transmission address ID
@@ -387,8 +389,9 @@ void ISA::VPLUS()
 
     port->sendFrame(outframe);
 
-    if (debug)
-      printCAN(&outframe);
+#if defined(DEBUG_ISA_OUTPUT)
+    printCAN(&outframe);
+#endif
     delay(500);
 
     sendSTORE();
@@ -403,13 +406,11 @@ void ISA::VPLUS()
 
 void ISA::VMINUS()
 {
-
   firstframe = false;
   STOP();
   delay(700);
   for (int i = 0; i < 9; i++)
   {
-
     Serial.println("set current minus\n");
 
     outframe.id = 0x411;   // Set our transmission address ID
@@ -427,8 +428,9 @@ void ISA::VMINUS()
 
     port->sendFrame(outframe);
 
-    if (debug)
-      printCAN(&outframe);
+#if defined(DEBUG_ISA_OUTPUT)
+    printCAN(&outframe);
+#endif
     delay(500);
 
     sendSTORE();
@@ -443,7 +445,6 @@ void ISA::VMINUS()
 
 void ISA::STOP()
 {
-
   // SEND STOP///////
 
   outframe.id = 0x411;   // Set our transmission address ID
@@ -460,14 +461,12 @@ void ISA::STOP()
   outframe.data.bytes[7] = 0x00;
   port->sendFrame(outframe);
 
-  if (debug)
-  {
-    printCAN(&outframe);
-  } // If the debug variable is set, show our transmitted frame
+#if defined(DEBUG_ISA_OUTPUT)
+  printCAN(&outframe);
+#endif
 }
 void ISA::sendSTORE()
 {
-
   // SEND STORE///////
 
   outframe.id = 0x411;   // Set our transmission address ID
@@ -484,8 +483,9 @@ void ISA::sendSTORE()
   outframe.data.bytes[7] = 0x00;
   port->sendFrame(outframe);
 
-  if (debug)
-    printCAN(&outframe); // If the debug variable is set, show our transmitted frame
+#if defined(DEBUG_ISA_OUTPUT)
+  printCAN(&outframe);
+#endif
 }
 
 void ISA::START()
@@ -507,8 +507,9 @@ void ISA::START()
   outframe.data.bytes[7] = 0x00;
   port->sendFrame(outframe);
 
-  if (debug)
-    printCAN(&outframe); // If the debug variable is set, show our transmitted frame
+#if defined(DEBUG_ISA_OUTPUT)
+  printCAN(&outframe);
+#endif
 }
 
 void ISA::RESTART()
@@ -529,8 +530,9 @@ void ISA::RESTART()
   outframe.data.bytes[7] = 0x00;
   port->sendFrame(outframe);
 
-  if (debug)
-    printCAN(&outframe); // If the debug variable is set, show our transmitted frame
+#if defined(DEBUG_ISA_OUTPUT)
+  printCAN(&outframe);
+#endif
 }
 
 void ISA::deFAULT()
@@ -551,8 +553,9 @@ void ISA::deFAULT()
   outframe.data.bytes[7] = 0x00;
   port->sendFrame(outframe);
 
-  if (debug)
-    printCAN(&outframe); // If the debug variable is set, show our transmitted frame
+#if defined(DEBUG_ISA_OUTPUT)
+  printCAN(&outframe);
+#endif
 }
 
 void ISA::initCurrent()
@@ -577,8 +580,9 @@ void ISA::initCurrent()
 
   port->sendFrame(outframe);
 
-  if (debug)
-    printCAN(&outframe);
+#if defined(DEBUG_ISA_OUTPUT)
+  printCAN(&outframe);
+#endif
   delay(500);
 
   sendSTORE();

--- a/SimpleISA.h
+++ b/SimpleISA.h
@@ -4,103 +4,92 @@
 /*  This library supports the ISA Scale IVT Modular current/voltage sensor device.  These devices measure current, up to three voltages, and provide temperature compensation.
 
     This library was written by Jack Rickard of EVtv - http://www.evtv.me copyright 2016
-    You are licensed to use this library for any purpose, commercial or private, 
+    You are licensed to use this library for any purpose, commercial or private,
     without restriction.
-    
-*/ 
+
+*/
 #include <Arduino.h>
-#include <DueTimer.h>
-#include "variant.h"
-#include <due_can.h>
-#define Serial SerialUSB
-            
-   
+#include "can_common.h"
+
 class ISA : public CANListener
 {
-   
-   
-      
-      
 
-   public:
-      ISA();
-    ~ISA();
-      void initialize();
-      void begin(int Port, int speed);
-      void initCurrent();
-      void sendSTORE();
-      void CPLUS();
-      void CMINUS();
-      void VPLUS();
-      void VMINUS();
-      void STOP();
-      void START();
-      void RESTART();
-      void deFAULT();
-      
+public:
+  ISA(CAN_COMMON *port, int enablePin = -1);
+  ~ISA();
+  void initialize();
+  void begin(int speed);
+  void initCurrent();
+  void sendSTORE();
+  void CPLUS();
+  void CMINUS();
+  void VPLUS();
+  void VMINUS();
+  void STOP();
+  void START();
+  void RESTART();
+  void deFAULT();
 
-      float Amperes;   // Floating point with current in Amperes
-      double AH;      //Floating point with accumulated ampere-hours
-      double KW;
-      double KWH;
+  float Amperes; // Floating point with current in Amperes
+  double AH;     // Floating point with accumulated ampere-hours
+  double KW;
+  double KWH;
 
+  double Voltage;
+  double Voltage1;
+  double Voltage2;
+  double Voltage3;
+  double VoltageHI;
+  double Voltage1HI;
+  double Voltage2HI;
+  double Voltage3HI;
+  double VoltageLO;
+  double Voltage1LO;
+  double Voltage2LO;
+  double Voltage3LO;
 
-      double Voltage;
-      double Voltage1;
-      double Voltage2;
-      double Voltage3;
-      double VoltageHI;
-      double Voltage1HI;
-      double Voltage2HI;
-      double Voltage3HI;
-      double VoltageLO;
-      double Voltage1LO;
-      double Voltage2LO;
-      double Voltage3LO;
+  double Temperature;
 
-      double Temperature;
-            
-      bool debug;
-      bool debug2;
-      bool firstframe;
-      int framecount;
-      unsigned long timestamp;
-      double milliamps;
-      long watt;
-      long As;
-      long lastAs;
-      long wh;
-        long lastWh;   
-      CANRaw *canPort;
-      uint8_t canEnPin;
-      int canSpeed;
-      uint8_t page;
-      
-   private:
-         CAN_FRAME frame;
-      unsigned long elapsedtime;
-      double  ampseconds;
-      int milliseconds ;
-      int seconds;
-      int minutes;
-      int hours;
-      char buffer[9];
-      char bigbuffer[90];
-      uint32_t inbox;
-      CAN_FRAME outframe;
-      
-      void gotFrame(CAN_FRAME *frame, int mailbox); // CAN interrupt service routine   
-      void printCAN(CAN_FRAME *frame);
-      void handle521(CAN_FRAME *frame);
-      void handle522(CAN_FRAME *frame);
-      void handle523(CAN_FRAME *frame);
-      void handle524(CAN_FRAME *frame);
-      void handle525(CAN_FRAME *frame);
-      void handle526(CAN_FRAME *frame);
-      void handle527(CAN_FRAME *frame);
-      void handle528(CAN_FRAME *frame);
-      
-                        
+  bool debug;
+  bool debug2;
+  bool firstframe;
+  int framecount;
+  unsigned long timestamp;
+  double milliamps;
+  long watt;
+  long As;
+  long lastAs;
+  long wh;
+  long lastWh;
+  CAN_COMMON *port;
+  int canSpeed;
+  uint8_t page;
+
+private:
+  CAN_FRAME frame;
+  unsigned long elapsedtime;
+  double ampseconds;
+  int milliseconds;
+  int seconds;
+  int minutes;
+  int hours;
+  char buffer[9];
+  char bigbuffer[90];
+  uint32_t inbox;
+  CAN_FRAME outframe;
+  int enablePin;
+  int interruptPin;
+
+  void gotFrame(CAN_FRAME *frame, int mailbox); // CAN interrupt service routine
+  void printCAN(CAN_FRAME *frame);
+  void handle521(CAN_FRAME *frame);
+  void handle522(CAN_FRAME *frame);
+  void handle523(CAN_FRAME *frame);
+  void handle524(CAN_FRAME *frame);
+  void handle525(CAN_FRAME *frame);
+  void handle526(CAN_FRAME *frame);
+  void handle527(CAN_FRAME *frame);
+  void handle528(CAN_FRAME *frame);
 };
 
 #endif /* SimpleISA_h */

--- a/SimpleISA.h
+++ b/SimpleISA.h
@@ -11,6 +11,12 @@
 #include <Arduino.h>
 #include "can_common.h"
 
+// add the following define in your code to print out current, voltages and temperatures
+// #define DEBUG_ISA_DATA
+
+// add the following define to print out CAN frames sent to the IVT-S
+// #define DEBUG_ISA_OUTPUT
+
 class ISA : public CANListener
 {
 
@@ -50,8 +56,6 @@ public:
 
   double Temperature;
 
-  bool debug;
-  bool debug2;
   bool firstframe;
   int framecount;
   unsigned long timestamp;

--- a/examples/ISAScaleTest/ISAScaleTest.ino
+++ b/examples/ISAScaleTest/ISAScaleTest.ino
@@ -1,188 +1,190 @@
 
 
-
 #include <due_can.h>
 #include "variant.h"
 #include <SimpleISA.h>
 
- #define Serial SerialUSB //Use native port
- template<class T> inline Print &operator <<(Print &obj, T arg) { obj.print(arg); return obj; } //Allow streaming
+#define Serial SerialUSB // Use native port
+template <class T>
+inline Print &operator<<(Print &obj, T arg)
+{
+  obj.print(arg);
+  return obj;
+} // Allow streaming
 
-float Version=2.00;
-uint16_t loopcount=0;
-unsigned long startime=0;
-unsigned long elapsedtime=0;
-uint port=0;
-uint16_t datarate=500;
+float Version = 2.00;
+uint16_t loopcount = 0;
+unsigned long startime = 0;
+unsigned long elapsedtime = 0;
+uint port = 0;
+uint16_t datarate = 500;
 
- ISA Sensor;  //Instantiate ISA Module Sensor object to measure current and voltage 
+ISA Sensor(&Can0); // Instantiate ISA Module Sensor object to measure current and voltage
 
-
-void setup() 
+void setup()
 {
   Serial.begin(115200);
-  Sensor.begin(port,datarate);  //Start ISA object on CAN 0 at 500 kbps
-   
-  Serial<<"\nISA Scale Startup Successful \n";
- 
+  Sensor.begin(datarate); // Start ISA object on CAN 0 at 500 kbps
+
+  Serial << "\nISA Scale Startup Successful \n";
+
   printMenu();
 }
 
 void loop()
 {
-  if(loopcount++==40000)
-    {
-        printStatus();
-        loopcount-0;
-    }    
-        checkforinput(); //Check keyboard for user input 
+  if (loopcount++ == 40000)
+  {
+    printStatus();
+    loopcount - 0;
+  }
+  checkforinput(); // Check keyboard for user input
 }
- 
- 
+
 void printStatus()
 {
   char buffer[40];
-   //printimestamp();  
-  
-   sprintf(buffer,"%4.2f",Sensor.Voltage); 
-   Serial<<"Volt:"<<buffer<<"v ";
-    sprintf(buffer,"%4.2f",Sensor.Voltage1); 
-   Serial<<"V1:"<<buffer<<"v ";
-   sprintf(buffer,"%4.2f",Sensor.Voltage2); 
-   Serial<<"V2:"<<buffer<<"v ";
-   sprintf(buffer,"%4.2f",Sensor.Voltage3); 
-   Serial<<"V3:"<<buffer<<"v ";
-  
-  sprintf(buffer,"%4.3f",Sensor.Amperes); 
-   Serial<<"Amps:"<<buffer<<"A ";
+  // printimestamp();
 
-  sprintf(buffer,"%4.3f",Sensor.KW); 
-   Serial<<buffer<<"kW ";
-  
-   sprintf(buffer,"%4.3f",Sensor.AH); 
-   Serial<<buffer<<"Ah "; 
+  sprintf(buffer, "%4.2f", Sensor.Voltage);
+  Serial << "Volt:" << buffer << "v ";
+  sprintf(buffer, "%4.2f", Sensor.Voltage1);
+  Serial << "V1:" << buffer << "v ";
+  sprintf(buffer, "%4.2f", Sensor.Voltage2);
+  Serial << "V2:" << buffer << "v ";
+  sprintf(buffer, "%4.2f", Sensor.Voltage3);
+  Serial << "V3:" << buffer << "v ";
 
-   sprintf(buffer,"%4.3f",Sensor.KWH); 
-   Serial<<buffer<<"kWh"; 
-   
-   sprintf(buffer,"%4.0f",Sensor.Temperature); 
-   Serial<<buffer<<"C "; 
-   
-   Serial<<"Frame:"<<Sensor.framecount<<" \n";
- }
+  sprintf(buffer, "%4.3f", Sensor.Amperes);
+  Serial << "Amps:" << buffer << "A ";
 
- void printimestamp()
+  sprintf(buffer, "%4.3f", Sensor.KW);
+  Serial << buffer << "kW ";
+
+  sprintf(buffer, "%4.3f", Sensor.AH);
+  Serial << buffer << "Ah ";
+
+  sprintf(buffer, "%4.3f", Sensor.KWH);
+  Serial << buffer << "kWh";
+
+  sprintf(buffer, "%4.0f", Sensor.Temperature);
+  Serial << buffer << "C ";
+
+  Serial << "Frame:" << Sensor.framecount << " \n";
+}
+
+void printimestamp()
 {
-  //Prints a timestamp to the serial port
-    elapsedtime=millis() - startime;
-    
-    int milliseconds = (elapsedtime/1) %1000 ;
-    int seconds = (elapsedtime / 1000) % 60 ;
-    int minutes = ((elapsedtime / (1000*60)) % 60);
-    int hours   = ((elapsedtime / (1000*60*60)) % 24);
-    char buffer[19]; 
-    sprintf(buffer,"%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
-    Serial<<buffer<<" ";
+  // Prints a timestamp to the serial port
+  elapsedtime = millis() - startime;
+
+  int milliseconds = (elapsedtime / 1) % 1000;
+  int seconds = (elapsedtime / 1000) % 60;
+  int minutes = ((elapsedtime / (1000 * 60)) % 60);
+  int hours = ((elapsedtime / (1000 * 60 * 60)) % 24);
+  char buffer[19];
+  sprintf(buffer, "%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
+  Serial << buffer << " ";
 }
 
 void printMenu()
 {
-   Serial<<"\f\n=========== ISA Scale  Sample Program Version "<<Version<<" ==============\n************ List of Available Commands ************\n\n";
-   Serial<<"  ?  - Print this menu\n ";
-   Serial<<"  d - toggles Debug off and on to print recieved CAN data traffic\n";
-   Serial<<"  D - toggles Debug2 off and on to print derived values\n";
-   Serial<<"  f  - zero frame count\n ";
-   Serial<<"  i  - initialize new sensor\n ";
-   Serial<<"  p  - Select new CAN port\n ";
-   Serial<<"  r  - Set new datarate\n ";
-   Serial<<"  z  - zero ampere-hours\n ";
-   
-   Serial<<"**************************************************************\n==============================================================\n\n";
-   
+  Serial << "\f\n=========== ISA Scale  Sample Program Version " << Version << " ==============\n************ List of Available Commands ************\n\n";
+  Serial << "  ?  - Print this menu\n ";
+  Serial << "  d - toggles Debug off and on to print recieved CAN data traffic\n";
+  Serial << "  D - toggles Debug2 off and on to print derived values\n";
+  Serial << "  f  - zero frame count\n ";
+  Serial << "  i  - initialize new sensor\n ";
+  Serial << "  p  - Select new CAN port\n ";
+  Serial << "  r  - Set new datarate\n ";
+  Serial << "  z  - zero ampere-hours\n ";
+
+  Serial << "**************************************************************\n==============================================================\n\n";
 }
 
 void checkforinput()
-{ 
-  //Checks for keyboard input from Native port 
-   if (Serial.available()) 
-     {
-      int inByte = Serial.read();
-      switch (inByte)
-       	{
-       	  case 'z':    //Zeroes ampere-hours
-              Sensor.KWH=0;
-              Sensor.AH=0;
-      		    Sensor.RESTART();
-      		  break;
-          
-          case 'p':    
-             getPort();
-            break;
-          
-	        case 'r':    
-             getRate();
-            break;
-          
-  
-	        case 'f':    
-      		    Sensor.framecount=0;
-      		  break;
-        
-          case 'd':     //Causes ISA object to print incoming CAN messages for debugging
-              Sensor.debug=!Sensor.debug;
-            break;
-            
-          case 'D':     //Causes ISA object to print derived values for debugging
-                 Sensor.debug2=!Sensor.debug2;
-      		  break;
-          
-          case 'i':     
-              Sensor.initialize();
-      		  break;
-           
-          case '?':     //Print a menu describing these functions
-              printMenu();
-      		  break;
-            
-          case '1':     
-              Sensor.STOP();
-            break; 
-        
-         case '3':     
-             Sensor.START();
-            break;
-         
-	        }    
-      }
-}
+{
+  // Checks for keyboard input from Native port
+  if (Serial.available())
+  {
+    int inByte = Serial.read();
+    switch (inByte)
+    {
+    case 'z': // Zeroes ampere-hours
+      Sensor.KWH = 0;
+      Sensor.AH = 0;
+      Sensor.RESTART();
+      break;
 
+    case 'p':
+      getPort();
+      break;
+
+    case 'r':
+      getRate();
+      break;
+
+    case 'f':
+      Sensor.framecount = 0;
+      break;
+
+    case 'd': // Causes ISA object to print incoming CAN messages for debugging
+      Sensor.debug = !Sensor.debug;
+      break;
+
+    case 'D': // Causes ISA object to print derived values for debugging
+      Sensor.debug2 = !Sensor.debug2;
+      break;
+
+    case 'i':
+      Sensor.initialize();
+      break;
+
+    case '?': // Print a menu describing these functions
+      printMenu();
+      break;
+
+    case '1':
+      Sensor.STOP();
+      break;
+
+    case '3':
+      Sensor.START();
+      break;
+    }
+  }
+}
 
 void getRate()
 {
-  Serial<<"\n Enter the Data Rate in Kbps you want for CAN : ";
-    while(Serial.available() == 0){}               
-    float V = Serial.parseFloat();  
-    if(V>0)
-      {
-       Serial<<"Datarate:"<<V<<"\n\n";
-       uint8_t rate=V;
-       
-       datarate=V*1000;
-       
-       Sensor.begin(port,datarate);
-      }
-}
+  Serial << "\n Enter the Data Rate in Kbps you want for CAN : ";
+  while (Serial.available() == 0)
+  {
+  }
+  float V = Serial.parseFloat();
+  if (V > 0)
+  {
+    Serial << "Datarate:" << V << "\n\n";
+    uint8_t rate = V;
 
+    datarate = V * 1000;
+
+    Sensor.begin(port, datarate);
+  }
+}
 
 void getPort()
 {
-  Serial<<"\n Enter port selection:  c0=CAN0 c1=CAN1 ";
-  while(Serial.available() == 0){}               
-  int P = Serial.parseInt();  
-   if(P>1) Serial<<"Entry out of range, enter 0 or 1 \n";
-  else 
-     {
-      port=P;
-     Sensor.begin(port,datarate); 
-       }           
+  Serial << "\n Enter port selection:  c0=CAN0 c1=CAN1 ";
+  while (Serial.available() == 0)
+  {
+  }
+  int P = Serial.parseInt();
+  if (P > 1)
+    Serial << "Entry out of range, enter 0 or 1 \n";
+  else
+  {
+    port = P;
+    Sensor.begin(port, datarate);
+  }
 }

--- a/library.json
+++ b/library.json
@@ -1,0 +1,30 @@
+{
+  "name": "SimpleISA",
+  "version": "0.1.0",
+  "description": "A CAN library to read current, voltage, and temperature from an IVT-S current sensor",
+  "authors": [
+    {
+      "name": "Isaac Kelly",
+      "url": "https://github.com/Isaac96/SimpleISA"
+    },
+    {
+      "name": "arber333",
+      "url": "https://github.com/arber333"
+    },
+    {
+      "name": "Nishanth Samala",
+      "url": "https://github.com/outlandnish"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arber333/SimpleISA.git"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/arber333/SimpleISA",
+  "dependencies": {
+    "can_common": "~0.4.0"
+  },
+  "frameworks": "Arduino",
+  "platforms": "*"
+}

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,11 @@
+name=SimpleISA
+version=0.1.0
+author=Isaac Kelly, arber333
+maintainer=arber333, Nishanth Samala <contact@outlandnish.com>
+sentence=A CAN library to read current, voltage, and temperature from an IVT-S current sensor
+paragraph=A CAN library to read current, voltage, and temperature from an IVT-S current sensor
+category=Communication
+url=https://github.com/arber333/SimpleISA
+architectures=*
+includes=SimpleISA.h
+depends=can_common


### PR DESCRIPTION
- Decouples library from `due_can`. Instead, it works with `CAN_COMMON`
- Default C++ formatting for legibility
- Adds an Arduino / PlatformIO library definition to the library to be discoverable in library managers
